### PR TITLE
Refactor the Ledger provider to be compatible to the latest Truffle version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "@atomix/eslint-config",
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 2017
+  }
+}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const ledgerOptions = {
   path: "44'/60'/0'/0", // ledger default derivation path
   askConfirm: false,
   accountsLength: 1,
-  accountsOffset: 0,
+  accountsOffset: 0
 };
 
 const provider = new LedgerWalletProvider(ledgerOptions, 'http://localhost:8545');
@@ -33,7 +33,7 @@ const provider = new LedgerWalletProvider(ledgerOptions, 'http://localhost:8545'
 
 ### Parameters:
 
-- `network`: `number`. Ethereum network ID. 1-mainnet, 3-ropsten, etc.
+- `networkId`: `number`. Ethereum network ID. 1-mainnet, 3-ropsten, etc.
 - `path`: `string`. HD derivation path.
 - `askConfirm`: `boolean`. If true, deployment of each contract must be confirmed.
 - `accountsLength`: `number`. Number of accounts to derivate.
@@ -56,14 +56,32 @@ module.exports = {
     development: {
       host: 'localhost',
       port: 8545,
-      network_id: '*', // Match any network id
+      network_id: '*' // Match any network id
     },
     ropsten: {
       provider: new LedgerWalletProvider(ledgerOptions, `https://ropsten.infura.io/${INFURA_APIKEY}`),
       network_id: 3,
-      gas: 4600000,
-    },
-  },
+      gas: 4600000
+    }
+  }
+};
+```
+
+## Debug mode
+
+You can enable the debug mode by passing `true` on the constructor. For instance:
+
+truffle.js
+
+```js
+module.exports = {
+  networks: {
+    ropsten: {
+      provider: new LedgerWalletProvider(ledgerOptions, `https://ropsten.infura.io/${INFURA_APIKEY}`, true), // Enable debug.
+      network_id: 3,
+      gas: 4600000
+    }
+  }
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,34 +1,33 @@
-const Web3 = require('web3')
-const TransportU2F = require('@ledgerhq/hw-transport-node-hid').default
+'use strict'
+
+/**
+ * Module dependencies.
+ */
+
+const FiltersSubprovider = require('web3-provider-engine/subproviders/filters.js')
 const ProviderEngine = require('web3-provider-engine')
 const ProviderSubprovider = require('web3-provider-engine/subproviders/provider.js')
-const FiltersSubprovider = require('web3-provider-engine/subproviders/filters.js')
+const TransportU2F = require('@ledgerhq/hw-transport-node-hid').default
+const Web3 = require('web3')
 const createLedgerSubprovider = require('@ledgerhq/web3-subprovider').default
 
+/**
+ * Exports.
+ */
 
-class LedgerProvider {
-  constructor(options, url) {
-    const getTransport = () => TransportU2F.create()
-    const ledger = createLedgerSubprovider(getTransport, options)
+module.exports = class LedgerProvider extends ProviderEngine {
+  constructor(options, url, debug) {
+    super()
 
-    this.engine = new ProviderEngine()
-    this.engine.addProvider(ledger)
-    this.engine.addProvider(new FiltersSubprovider())
-    this.engine.addProvider(new ProviderSubprovider(new Web3.providers.HttpProvider(url)))
-    this.engine.start()
-  }
+    this.addProvider(createLedgerSubprovider(async () => {
+      const transport = await TransportU2F.create()
 
-  sendAsync(...args) {
-    this.engine.sendAsync.apply(this.engine, ...args)
-  }
+      transport.setDebugMode(!!debug)
 
-  send(...args) {
-    return this.engine.send.apply(this.engine, ...args)
-  }
-
-  getAddress() {
-    return this.address
+      return transport
+    }, options))
+    this.addProvider(new FiltersSubprovider())
+    this.addProvider(new ProviderSubprovider(new Web3.providers.HttpProvider(url)))
+    this.start()
   }
 }
-
-module.exports = LedgerProvider

--- a/package.json
+++ b/package.json
@@ -2,35 +2,37 @@
   "name": "truffle-ledger-provider",
   "version": "0.0.4",
   "description": "Ledger Wallet-enabled Web3 provider",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "keywords": [
+    "ethereum",
+    "hardware",
+    "ledger",
+    "provider",
+    "wallet"
+  ],
+  "homepage": "https://github.com/hussy-io/truffle-ledger-provider#readme",
+  "bugs": {
+    "url": "https://github.com/hussy-io/truffle-ledger-provider/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hussy-io/truffle-ledger-provider.git"
   },
-  "keywords": [
-    "ethereum",
-    "ledger",
-    "hardware",
-    "wallet",
-    "provider"
-  ],
-  "author": "Peter Tulala <peter@hussy.io>",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/hussy-io/truffle-ledger-provider/issues"
+  "author": "Peter Tulala <peter@hussy.io>",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "homepage": "https://github.com/hussy-io/truffle-ledger-provider#readme",
   "dependencies": {
-    "ethereumjs-wallet": "^0.6.0",
-    "web3": "^0.18.2",
-    "web3-provider-engine": "^14.0.5",
-    "@ledgerhq/hw-transport-node-hid": "^4.7.6",
-    "@ledgerhq/web3-subprovider": "^4.7.3"
+    "@ledgerhq/hw-transport-node-hid": "^4.24.0",
+    "@ledgerhq/web3-subprovider": "^4.31.0",
+    "ethereumjs-wallet": "^0.6.2",
+    "web3": "^0.20.6",
+    "web3-provider-engine": "^14.1.0"
   },
   "devDependencies": {
-    "@atomix/eslint-config": "^6.4.0"
+    "@atomix/eslint-config": "^6.4.0",
+    "eslint": "^4.19.0"
   }
 }


### PR DESCRIPTION
This PR fixes this provider to be compatible to the latest version of truffle@4.1.14.

Also, besides fixing some typos in the README, we are simplifying the provider by extending the `ProviderEngine` class and bumping some dependencies to the latest versions.

Successfully tested with Ledger Nano S.

Closes #5.